### PR TITLE
Support references to specific commit SHAs

### DIFF
--- a/pkg/apis/operator/v1alpha1/types.go
+++ b/pkg/apis/operator/v1alpha1/types.go
@@ -48,9 +48,14 @@ type Git struct {
 	// cloned and the specified tag is checked out.
 	Source string `yaml:"source"`
 
-	// Tag of the KUDO operator version.
-	Tag string `yaml:"tag"`
-
 	// Directory where the KUDO operator is defined in the Git repository.
 	Directory string `yaml:"directory"`
+
+	// Tag (or branch) of the KUDO operator version.
+	Tag string `yaml:"tag,omitempty"`
+
+	// Optional SHA of the KUDO operator version if a branch is used instead of
+	// a tag. If this isn't set, the latest commit of the referenced branch will
+	// be used.
+	SHA string `yaml:"sha,omitempty"`
 }

--- a/pkg/internal/apis/operator/encode/convert.go
+++ b/pkg/internal/apis/operator/encode/convert.go
@@ -51,8 +51,9 @@ func convertV1Alpha1Version(in v1alpha1.Version) operator.Version {
 func convertV1Alpha1Git(in v1alpha1.Git) operator.Git {
 	out := operator.Git{
 		Source:    in.Source,
-		Tag:       in.Tag,
 		Directory: in.Directory,
+		Tag:       in.Tag,
+		SHA:       in.SHA,
 	}
 
 	return out

--- a/pkg/internal/apis/operator/types.go
+++ b/pkg/internal/apis/operator/types.go
@@ -39,9 +39,14 @@ type Git struct {
 	// cloned and the specified tag is checked out.
 	Source string
 
-	// Tag of the KUDO operator version.
-	Tag string
-
 	// Directory where the KUDO operator is defined in the Git repository.
 	Directory string
+
+	// Tag (or branch) of the KUDO operator version.
+	Tag string
+
+	// Optional SHA of the KUDO operator version if a branch is used instead of
+	// a tag. If this isn't set, the latest commit of the referenced branch will
+	// be used.
+	SHA string
 }

--- a/pkg/internal/resolvers/git/git_test.go
+++ b/pkg/internal/resolvers/git/git_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestResolve(t *testing.T) {
-	testClone := func(ctx context.Context, url, branch, tempDir string) error {
-		if url == "example.org" && branch == "test" {
+	testClone := func(ctx context.Context, tempDir, url, branch, sha string) error {
+		if url == "example.org" && branch == "test" && sha == "" {
 			return nil
 		}
 

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -124,7 +124,7 @@ func getResolver(o operator.Operator, version operator.Version) (resolvers.Resol
 		}
 
 		// TODO: cache git sources to ensure that repositories are only cloned once per source
-		resolver := git.NewResolver(source.URL, version.Git.Tag, version.Git.Directory)
+		resolver := git.NewResolver(source.URL, version.Git.Tag, version.Git.SHA, version.Git.Directory)
 
 		return resolver, nil
 	}


### PR DESCRIPTION
In addition of using a tag name to reference a specific version of an operator package, a combination of branch and SHA of a commit can be used as well.