### PR TITLE
Directly check out SHAs.

### DIFF
--- a/pkg/apis/operator/v1alpha1/types.go
+++ b/pkg/apis/operator/v1alpha1/types.go
@@ -51,11 +51,10 @@ type Git struct {
 	// Directory where the KUDO operator is defined in the Git repository.
 	Directory string `yaml:"directory"`
 
-	// Tag (or branch) of the KUDO operator version.
+	// Tag of the KUDO operator version. Either this or 'SHA' has to be set.
 	Tag string `yaml:"tag,omitempty"`
 
-	// Optional SHA of the KUDO operator version if a branch is used instead of
-	// a tag. If this isn't set, the latest commit of the referenced branch will
-	// be used.
+	// SHA of the KUDO operator version if a branch is used instead of
+	// a tag. Either this or 'Tag' has to be set.
 	SHA string `yaml:"sha,omitempty"`
 }

--- a/pkg/internal/apis/operator/types.go
+++ b/pkg/internal/apis/operator/types.go
@@ -42,11 +42,10 @@ type Git struct {
 	// Directory where the KUDO operator is defined in the Git repository.
 	Directory string
 
-	// Tag (or branch) of the KUDO operator version.
+	// Tag of the KUDO operator version. Either this or 'SHA' has to be set.
 	Tag string
 
-	// Optional SHA of the KUDO operator version if a branch is used instead of
-	// a tag. If this isn't set, the latest commit of the referenced branch will
-	// be used.
+	// SHA of the KUDO operator version if a branch is used instead of
+	// a tag. Either this or 'Tag' has to be set.
 	SHA string
 }

--- a/pkg/internal/resolvers/git/git_test.go
+++ b/pkg/internal/resolvers/git/git_test.go
@@ -9,25 +9,71 @@ import (
 )
 
 func TestResolve(t *testing.T) {
-	testClone := func(ctx context.Context, tempDir, url, branch, sha string) error {
-		if url == "example.org" && branch == "test" && sha == "" {
-			return nil
+	tests := []struct {
+		name      string
+		cloneFake func(context.Context, string, string, string, string) error
+		branch    string
+		sha       string
+		expectErr bool
+	}{
+		{
+			name: "resolve branch",
+			cloneFake: func(ctx context.Context, tempDir, url, branch, sha string) error {
+				if url == "example.org" && branch == "test" && sha == "" {
+					return nil
+				}
+
+				return errors.New("wrong URL and branch")
+			},
+			branch:    "test",
+			sha:       "",
+			expectErr: false,
+		},
+		{
+			name: "resolve SHA",
+			cloneFake: func(ctx context.Context, tempDir, url, branch, sha string) error {
+				if url == "example.org" && branch == "" && sha == "abcdefg" {
+					return nil
+				}
+
+				return errors.New("wrong URL and SHA")
+			},
+			branch:    "",
+			sha:       "abcdefg",
+			expectErr: false,
+		},
+		{
+			name:      "neither branch nor SHA set",
+			cloneFake: nil,
+			branch:    "",
+			sha:       "",
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		resolver := &Resolver{
+			URL:               "example.org",
+			Branch:            test.branch,
+			SHA:               test.sha,
+			OperatorDirectory: "operator",
+			gitClone:          test.cloneFake,
 		}
 
-		return errors.New("wrong URL and branch")
+		_, remover, err := resolver.Resolve(context.Background())
+
+		if remover != nil {
+			defer func() {
+				assert.NoError(t, remover())
+			}()
+		}
+
+		if test.expectErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
 	}
-
-	resolver := &Resolver{
-		URL:               "example.org",
-		Branch:            "test",
-		OperatorDirectory: "operator",
-		gitClone:          testClone,
-	}
-
-	_, remover, err := resolver.Resolve(context.Background())
-	assert.NoError(t, err)
-
-	defer func() {
-		assert.NoError(t, remover())
-	}()
 }


### PR DESCRIPTION
This removes the necessity to set a branch when referencing SHAs in Git repositories.

Fixes #4 