### PR TITLE
Use 'appVersion' and 'operatorVersion' in API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,20 @@ Consider an operator that is developed in a Git repository. The actual operator 
 apiVersion: index.kudo.dev/v1alpha1
 kind: Operator
 name: MyOperator
-git-sources:
-- name: my-git-repository
-  url: https://github.com/example/myoperator.git
+gitSources:
+  - name: my-git-repository
+    url: https://github.com/example/myoperator.git
 versions:
-- version: "1.0.0"
-  git:
-    source: my-git-repository
-    directory: operator
-    tag: "v1.0.0"
-- version: "2.0.0"
-  git:
-    source: my-git-repository
-    directory: operator
-    tag: "v2.0.0"
+  - operatorVersion: "1.0.0"
+    git:
+      source: my-git-repository
+      directory: operator
+      tag: "v1.0.0"
+  - operatorVersion: "2.0.0"
+    git:
+      source: my-git-repository
+      directory: operator
+      tag: "v2.0.0"
 ```
 
 Running `kitt update` with this YAML as an argument will check out the referenced Git repository with the specified tags `v1.0.0` and `v2.0.0`, build tarballs from the operator package in the `operator` folder, and add these tarballs to a KUDO repository.

--- a/pkg/apis/operator/v1alpha1/types.go
+++ b/pkg/apis/operator/v1alpha1/types.go
@@ -8,7 +8,7 @@ type Operator struct {
 	Name string `yaml:"name"`
 
 	// GitSources are optional references to Git repositories.
-	GitSources []GitSource `yaml:"git-sources,omitempty"`
+	GitSources []GitSource `yaml:"gitSources,omitempty"`
 
 	// Versions of the operator.
 	Versions []Version `yaml:"versions"`
@@ -32,7 +32,11 @@ type GitSource struct {
 
 // Version describes a version of a KUDO operator.
 type Version struct {
-	Version string `yaml:"version"`
+	// OperatorVersion of the KUDO operator.
+	OperatorVersion string `yaml:"operatorVersion"`
+
+	// AppVersion of the KUDO operator, optional.
+	AppVersion string `yaml:"appVersion,omitempty"`
 
 	// Git specifies a version as a directory in a Git repository with a
 	// specific tag.

--- a/pkg/internal/apis/operator/encode/convert.go
+++ b/pkg/internal/apis/operator/encode/convert.go
@@ -36,8 +36,9 @@ func convertV1Alpha1GitSource(in v1alpha1.GitSource) operator.GitSource {
 
 func convertV1Alpha1Version(in v1alpha1.Version) operator.Version {
 	out := operator.Version{
-		Version: in.Version,
-		URL:     in.URL,
+		OperatorVersion: in.OperatorVersion,
+		AppVersion:      in.AppVersion,
+		URL:             in.URL,
 	}
 
 	if in.Git != nil {

--- a/pkg/internal/apis/operator/types.go
+++ b/pkg/internal/apis/operator/types.go
@@ -1,5 +1,7 @@
 package operator
 
+import "fmt"
+
 // Operator describes the location of a KUDO operator.
 type Operator struct {
 	// Name of the operator.
@@ -23,7 +25,11 @@ type GitSource struct {
 
 // Version describes a version of a KUDO operator.
 type Version struct {
-	Version string
+	// OperatorVersion of the KUDO operator.
+	OperatorVersion string
+
+	// AppVersion of the KUDO operator, optional.
+	AppVersion string
 
 	// Git specifies a version as a directory in a Git repository with a
 	// specific tag.
@@ -31,6 +37,16 @@ type Version struct {
 
 	// URL specifies a version as a URL of a package tarball.
 	URL *string
+}
+
+// Version prints the version as a combination of appVersion and operatorVersion
+// as described in KEP-19.
+func (v Version) Version() string {
+	if v.AppVersion != "" {
+		return fmt.Sprintf("%s_%s", v.AppVersion, v.OperatorVersion)
+	}
+
+	return v.OperatorVersion
 }
 
 // Git references a specific tag of a Git repository of a KUDO operator.

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -47,7 +47,7 @@ func Update(
 	for _, operator := range operators {
 		for _, version := range operator.Versions {
 			log.WithField("operator", operator.Name).
-				WithField("version", version.Version).
+				WithField("version", version.Version()).
 				WithField("repository", repoURL).
 				WithField("path", repoPath).
 				Info("Updating operator")
@@ -68,7 +68,7 @@ func updateOperator(
 	syncedRepo *repo.SyncedRepo,
 	force bool,
 ) (err error) {
-	operatorName := fmt.Sprintf("%s-%s", operator.Name, version.Version)
+	operatorName := fmt.Sprintf("%s-%s", operator.Name, version.Version())
 
 	resolver, err := getResolver(operator, version)
 	if err != nil {
@@ -102,13 +102,13 @@ func updateOperator(
 		}
 
 		log.WithField("operator", operator.Name).
-			WithField("version", version.Version).
+			WithField("version", version.Version()).
 			WithField("repository", syncedRepo.URL).
 			WithField("tarball", pkgName).
 			Info("Added operator to the repository")
 	} else {
 		log.WithField("operator", operator.Name).
-			WithField("version", version.Version).
+			WithField("version", version.Version()).
 			WithField("repository", syncedRepo.URL).
 			Info("Operator is already in the repository")
 	}


### PR DESCRIPTION
This change reflects KUDO's version handling as described in KEP-19.