### PR TITLE
Use subtests for table-driven tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/kudobuilder/kudo v0.15.0
 	github.com/sirupsen/logrus v1.6.0
-	github.com/spf13/afero v1.3.2
+	github.com/spf13/afero v1.3.3
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.6.1
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
-github.com/spf13/afero v1.3.2 h1:GDarE4TJQI52kYSbSAmLiId1Elfj+xgSDqrUZxFhxlU=
-github.com/spf13/afero v1.3.2/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
+github.com/spf13/afero v1.3.3 h1:p5gZEKLYoL7wh8VrJesMaYeNxdEd1v3cb4irOk9zB54=
+github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=

--- a/pkg/internal/repo/package_test.go
+++ b/pkg/internal/repo/package_test.go
@@ -87,7 +87,11 @@ func TestEqual(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := test.a.Equal(test.b)
-		assert.Equal(t, test.expected, actual, test.name)
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.a.Equal(test.b)
+			assert.Equal(t, test.expected, actual)
+		})
 	}
 }

--- a/pkg/internal/repo/syncedrepo_test.go
+++ b/pkg/internal/repo/syncedrepo_test.go
@@ -57,8 +57,12 @@ func TestContains(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := repo.Contains(test.pkg)
-		assert.Equal(t, test.expected, actual, test.name)
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			actual := repo.Contains(test.pkg)
+			assert.Equal(t, test.expected, actual)
+		})
 	}
 }
 

--- a/pkg/internal/resolver/git/git_test.go
+++ b/pkg/internal/resolver/git/git_test.go
@@ -54,26 +54,28 @@ func TestResolve(t *testing.T) {
 	for _, test := range tests {
 		test := test
 
-		resolver := &Resolver{
-			URL:               "example.org",
-			Branch:            test.branch,
-			SHA:               test.sha,
-			OperatorDirectory: "operator",
-			gitClone:          test.cloneFake,
-		}
+		t.Run(test.name, func(t *testing.T) {
+			resolver := &Resolver{
+				URL:               "example.org",
+				Branch:            test.branch,
+				SHA:               test.sha,
+				OperatorDirectory: "operator",
+				gitClone:          test.cloneFake,
+			}
 
-		_, remover, err := resolver.Resolve(context.Background())
+			_, remover, err := resolver.Resolve(context.Background())
 
-		if remover != nil {
-			defer func() {
-				assert.NoError(t, remover())
-			}()
-		}
+			if remover != nil {
+				defer func() {
+					assert.NoError(t, remover())
+				}()
+			}
 
-		if test.expectErr {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-		}
+			if test.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export GOLANGCILINT_VERSION='1.29.0'
+export GOLANGCILINT_VERSION='1.30.0'
 
 export GOBIN=$PWD/bin
 export PATH=$GOBIN:$PATH


### PR DESCRIPTION
This allows better visibility and matching of subtests.
Also updates some third-party dependencies.