### PR TITLE
Add a "skipVerify" attribute to version 

### DIFF
--- a/pkg/apis/operator/v1alpha1/types.go
+++ b/pkg/apis/operator/v1alpha1/types.go
@@ -44,6 +44,10 @@ type Version struct {
 
 	// URL specifies a version as a URL of a package tarball.
 	URL *string `yaml:"url,omitempty"`
+
+	// SkipVerify can be used to skip the KUDO package verification step to publish
+	// old versions of an operator that would fail the package verification
+	SkipVerify *bool `yaml:"url,omitempty"`
 }
 
 // Git references a specific tag of a Git repository of a KUDO operator.

--- a/pkg/internal/apis/operator/encode/convert.go
+++ b/pkg/internal/apis/operator/encode/convert.go
@@ -46,6 +46,9 @@ func convertV1Alpha1Version(in v1alpha1.Version) operator.Version {
 		out.Git = &git
 	}
 
+	if in.SkipVerify != nil {
+		out.SkipVerify = *in.SkipVerify
+	}
 	return out
 }
 

--- a/pkg/internal/apis/operator/types.go
+++ b/pkg/internal/apis/operator/types.go
@@ -37,6 +37,10 @@ type Version struct {
 
 	// URL specifies a version as a URL of a package tarball.
 	URL *string
+
+	// SkipVerify can be used to skip the KUDO package verification step to publish
+	// old versions of an operator that would fail the package verification
+	SkipVerify bool
 }
 
 // Version prints the version as a combination of appVersion and operatorVersion

--- a/pkg/internal/validation/validate.go
+++ b/pkg/internal/validation/validate.go
@@ -16,7 +16,9 @@ func Validate(operator operator.Operator, version operator.Version, pkg repo.Pac
 	result := Result{}
 
 	validateVersion(version, pkg, &result)
-	validateVerify(pkg, &result)
+	if !version.SkipVerify {
+		validateVerify(pkg, &result)
+	}
 
 	return result
 }


### PR DESCRIPTION
This will allow us to add old versions to the index which would fail the kudo package verify.

We should discuss this though - maybe there's a better option?

Related to #11 